### PR TITLE
Fixes bug for Rust namepsace in generated code

### DIFF
--- a/src/bin/ion/commands/generate/generator.rs
+++ b/src/bin/ion/commands/generate/generator.rs
@@ -333,7 +333,7 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
             self.generate_abstract_data_type(&isl_type_name, isl_type)?;
             // Since the fully qualified name of this generator represents the current fully qualified name,
             // remove it before generating code for the next ISL type.
-            self.current_type_fully_qualified_name.pop();
+            L::reset_namespace(&mut self.current_type_fully_qualified_name);
         }
 
         Ok(())

--- a/src/bin/ion/commands/generate/utils.rs
+++ b/src/bin/ion/commands/generate/utils.rs
@@ -71,6 +71,9 @@ pub trait Language {
     ///     i.e. given namespace path as `foo::Foo`, it will first remove `Foo` and then add the current type as `foo::nested_type::NestedType`.
     fn add_type_to_namespace(is_nested_type: bool, type_name: &str, namespace: &mut Vec<String>);
 
+    /// Resets the namespace when code generation is complete for a single ISL type
+    fn reset_namespace(namespace: &mut Vec<String>);
+
     /// Returns the `FullyQualifiedReference` that represents the target type as optional in the given programming language
     /// e.g. In Java, it will return "java.util.Optional<T>"
     ///     In Rust, it will return "Option<T>"
@@ -164,6 +167,11 @@ impl Language for JavaLanguage {
 
     fn add_type_to_namespace(_is_nested_type: bool, type_name: &str, namespace: &mut Vec<String>) {
         namespace.push(type_name.to_case(Case::UpperCamel))
+    }
+
+    fn reset_namespace(namespace: &mut Vec<String>) {
+        // resets the namespace by removing current abstract dta type name
+        namespace.pop();
     }
 
     fn target_type_as_optional(
@@ -318,6 +326,12 @@ impl Language for RustLanguage {
         }
         namespace.push(type_name.to_case(Case::Snake)); // Add this type's module name to the namespace path
         namespace.push(type_name.to_case(Case::UpperCamel)) // Add this type itself to the namespace path
+    }
+
+    fn reset_namespace(namespace: &mut Vec<String>) {
+        // Resets the namespace by removing current abstract data type name and module name
+        namespace.pop();
+        namespace.pop();
     }
 
     fn target_type_as_optional(


### PR DESCRIPTION
### Description: 
This PR fixes a bug in Rust namespace for generated code.

### Issue:
Generated code in Rust uses fully qualified names for its nested types. Previously we added `add_namespace` API on `Language` which modified the namespace by adding module name and type name to it. Although while resetting the namespace to be sued by next ISL type, it didn't pop out both module name and type name.(Only type name was being popped out)
This was not detected previously because there was only a single nested type in the test schema folder.

### Generated code in Rust:

Generated code in Rust can be found [here](https://gist.github.com/desaikd/e64ee9b1ddb9a34384a90864cdf163e2). (Note that line 59 in the generated code now has correct fully qualified name)
